### PR TITLE
Mejorar la responsividad de la rocapp

### DIFF
--- a/rocapp/src/app/app-routing.module.ts
+++ b/rocapp/src/app/app-routing.module.ts
@@ -2,10 +2,9 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import {APP_BASE_HREF} from '@angular/common';
 import {EmptyRouteComponent} from './empty-route/empty-route.component';
-import {AppComponent} from './app.component';
 
 
-const routes: Routes = [{ path: '**', component: EmptyRouteComponent }]
+const routes: Routes = [{ path: '**', component: EmptyRouteComponent }];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/rocapp/src/app/app.component.css
+++ b/rocapp/src/app/app.component.css
@@ -1,5 +1,4 @@
-.propuestas {
+rocapp-tarjeton {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  flex: 1;
 }

--- a/rocapp/src/app/tarjeton/tarjeton.component.css
+++ b/rocapp/src/app/tarjeton/tarjeton.component.css
@@ -1,184 +1,66 @@
 .tarjeton {
   display: flex;
-  background-color: white;
-  -moz-transition: box-shadow 0.5s;
-  -o-transition: box-shadow 0.5s;
-  -webkit-transition: box-shadow 0.5s;
-  transition: box-shadow 0.5s;
-}
-
-.tarjeton__body {
-  flex: 4;
-  overflow: auto;
-}
-
-.tarjeton__body-header {
-  padding: .8em .8em .1em .8em;
-  border-bottom: 1px solid #eee;
-  display: flex;
-  justify-content: space-between;
-}
-
-.tarjeton__body-main {
-  padding: .8em 1.5em;
-}
-
-.tarjeton__body-main .title-box {
-  font-size: 1.38vw;
-  max-height: 120px;
-  padding-bottom: 1rem;
-}
-
-.thumbnail-box--thum {
-  display: inline-block;
-  background-color: #eee;
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: 100% 100%;
-  width: 75px;
-  height: 75px;
-}
-
-.thumbnail-box--title {
-  display: inline-block;
-  width: calc(100% - 85px);
-}
-
-.thumbnail-box * {
-  vertical-align: top;
-}
-
-.thumbnail {
-  display: block;
-  padding: 4px;
-  margin-bottom: 20px;
-  line-height: 1.42857;
-  background-color: #fff;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  -webkit-transition: border 0.2s ease-in-out;
-  -o-transition: border 0.2s ease-in-out;
-  transition: border 0.2s ease-in-out;
-}
-
-.tarjeton__aside {
   flex: 1;
-  padding: 3em 1.5em 0 1.5em;
+}
+
+.tarjeton-main {
+  flex: 3;
+  background-color: white;
+  height: 100%;
+  padding-left: 1.3vw;
+  padding-right: 1.3vw;
+  display: flex;
+  flex-direction: column;
+}
+
+.tarjeton-aside {
   background-color: #414141;
   color: white;
   display: flex;
-  flex-flow: column;
-  flex-wrap: wrap;
-  align-items: center;
-  position: relative;
-}
-
-.tarjeton__aside .rocas-faltantes {
-  -moz-border-radius: 50%;
-  border-radius: 50%;
-  display: flex;
-  flex-wrap: nowrap;
   flex-direction: column;
-  background-color: #9FCC3B;
-  height: 125px;
-  width: 125px;
-  text-align: center;
-  font-size: 55px;
-  padding-top: .3em;
+  justify-content: center;
 }
 
-.tarjeton__aside h5 {
-  font-size: 16px;
-  font-weight: 600;
+.texto-header {
+  border-bottom: 1px solid #eee;
+  display: flex;
+  justify-content: left;
+  align-items: center;
 }
 
-.tarjeton__aside .rocas-faltantes--titulo {
-  font-weight: 800;
-  font-size: 18px;
-}
-
-.tarjeton__aside .rocas-faltantes--numero {
-  line-height: 50px;
-}
-
-.tarjeton__aside .btn-aside {
-  position: absolute;
-  width: 80%;
-  bottom: 15px;
-  left: 10%;
-  font-weight: bold;
-  color: white;
-  background-color: #68BD44;
-}
-
-.tarjeton__aside .btn-aside:hover {
-  transition: background-color 0.5s;
-  -webkit-box-shadow: 0 0 4px rgba(0,0,0,0.6);
-  -moz-box-shadow: 0 0 4px rgba(0,0,0,0.6);
-  box-shadow: 0 0 4px rgba(0,0,0,0.6);
-  color: white;
-  background-color: #9FCC3B;
-}
-
-.tarjeton__aside .btn-aside img {
-  height: 20px;
-}
-
-.btn {
-  display: inline-block;
-  margin-bottom: 0;
-  font-weight: normal;
-  text-align: center;
-  vertical-align: middle;
-  touch-action: manipulation;
-  cursor: pointer;
-  background-image: none;
-  border: 1px solid transparent;
-  white-space: nowrap;
-  padding: 6px 12px;
-  font-size: 14px;
-  line-height: 1.42857;
-  border-radius: 4px;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-.tarjeton.status--completa .tarjeton__aside .btn-aside {
-  background-color: transparent;
-  border: 2px solid #9FCC3B;
-}
-
-.little-text {
-  font-size: 12px;
+.chiquito {
+  font-size: 0.8rem;
+  margin-right: 0.8rem;
   font-style: italic;
   color: #bbb;
 }
 
-h5 {
-  margin-top: 10px;
-  margin-bottom: 10px;
+.tarjeton-text {
+  flex: 4;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 4vh;
+  max-height: 120px;
 }
 
-a {
-  color: #337ab7;
-  text-decoration: none;
+.rocas-faltantes {
+  background-color: #9FCC3B;
+  border-radius: 50%;
+  height: 9vw;
+  width: 9vw;
+  margin-left: 0.4vw;
+  margin-right: 0.4vw;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  white-space: nowrap;
+  font-weight: bold;
 }
 
-img {
-  vertical-align: middle;
-  border: 0;
-}
-
-div {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font: inherit;
-  vertical-align: baseline;
-}
-
-* {
-  box-sizing: border-box;
+.numerito {
+  font-size: 8vh;
+  margin-top: -1vh;
+  margin-bottom: -1.5vh;
 }

--- a/rocapp/src/app/tarjeton/tarjeton.component.css
+++ b/rocapp/src/app/tarjeton/tarjeton.component.css
@@ -24,7 +24,6 @@
 .texto-header {
   border-bottom: 1px solid #eee;
   display: flex;
-  justify-content: left;
   align-items: center;
 }
 
@@ -41,7 +40,6 @@
   justify-content: center;
   align-items: center;
   font-size: 4vh;
-  max-height: 120px;
 }
 
 .rocas-faltantes {

--- a/rocapp/src/app/tarjeton/tarjeton.component.html
+++ b/rocapp/src/app/tarjeton/tarjeton.component.html
@@ -1,26 +1,19 @@
-<div class="tarjeton status--completa">
-  <div class="tarjeton__body">
-    <div class="tarjeton__body-header">
-      <p>
-        <span class="little-text">Propuesto por: </span>
-        <strong>ludat</strong>
+<div class="tarjeton">
+  <div class="tarjeton-main">
+    <div class="tarjeton-header">
+      <p class="texto-header">
+        <span class="chiquito">Propuesto por:</span> <strong>Ludat</strong>
       </p>
     </div>
-    <div class="tarjeton__body-main">
-      <div class="title-box">
-        <div class="thumbnail-box">
-          <div class="thumbnail-box--title">
-            <span class="title-box">Haskell Programming From First Principles</span>
-          </div>
-        </div>
-      </div>
+    <div class="tarjeton-text">
+      Haskell Programming From First Principles
     </div>
   </div>
-  <div class="tarjeton__aside">
+  <div class="tarjeton-aside">
     <div class="rocas-faltantes">
-      <span class="rocas-faltantes--titulo">Nos faltan:</span>
-      <span class="rocas-faltantes--numero ng-binding">3</span>
-      <span class="rocas-faltantes--titulo">Rocas</span>
+      <span>Nos faltan: </span>
+      <span class="numerito">3</span>
+      <span>Rocas</span>
     </div>
   </div>
 </div>

--- a/rocapp/src/styles.css
+++ b/rocapp/src/styles.css
@@ -1,1 +1,5 @@
 /* You can add global styles to this file, and also import other style files */
+rocapp-root {
+  flex: 1;
+  display: flex;
+}


### PR DESCRIPTION
Quité muchos de los estilos choripasteados por estilos custom usando más
flexbox y unidades relativas.

Se vería de la siguiente conformidad:
![image](https://user-images.githubusercontent.com/7256526/64467492-7e864280-d0ef-11e9-9f58-f38e7d478259.png)
